### PR TITLE
Support enode-id

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,11 @@ jobs:
   cargo-fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+
+    - uses: actions/checkout@v3
     - name: Get latest version of stable rust
       run: rustup update stable
     - name: Check formatting with cargofmt
@@ -15,7 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-      - uses: actions/checkout@v2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+      - uses: actions/checkout@v3
       - name: Get latest version of stable rust
         run: rustup update stable
       - name: Run tests in release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ name = "enr-cli"
 path = "src/main.rs"
 
 [dependencies]
-enr = { version = "0.5.1", features = ["ed25519"] }
-clap = "3.0.14"
-libp2p-core = "0.31.1"
+enr = { version = "0.7.0", features = ["ed25519"] }
+clap = "4.0.18"
+libp2p-core = "0.36.0"
 hex = "0.4.3"
 eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"

--- a/src/build.rs
+++ b/src/build.rs
@@ -9,9 +9,9 @@ use std::io::prelude::*;
 pub fn build(matches: &clap::ArgMatches) -> Result<(), &'static str> {
     // Generate or import a key for the ENR
     let key = {
-        let key_bytes = if let Some(priv_key) = matches.value_of("private-key") {
+        let key_bytes = if let Some(priv_key) = matches.get_one::<String>("private-key") {
             Some(hex::decode(priv_key).map_err(|_| "Invalid private key hex bytes")?)
-        } else if let Some(key_file) = matches.value_of("key-file") {
+        } else if let Some(key_file) = matches.get_one::<String>("key-file") {
             let mut file = File::open(key_file).map_err(|_| "Cannot find key-file")?;
             let mut key_bytes: Vec<u8> = Vec::with_capacity(36);
             file.read_to_end(&mut key_bytes)
@@ -38,24 +38,24 @@ pub fn build(matches: &clap::ArgMatches) -> Result<(), &'static str> {
 
     let mut enr_builder = enr::EnrBuilder::new("v4");
 
-    if let Some(seq) = matches.value_of("seq") {
+    if let Some(seq) = matches.get_one::<String>("seq") {
         enr_builder.seq(seq.parse::<u64>().map_err(|_| "Invalid sequence number")?);
     }
-    if let Some(ip) = matches.value_of("ip") {
+    if let Some(ip) = matches.get_one::<String>("ip") {
         enr_builder.ip(ip
             .parse::<std::net::IpAddr>()
             .map_err(|_| "Invalid ip address")?);
     }
 
-    if let Some(tcp) = matches.value_of("tcp-port") {
-        enr_builder.tcp(tcp.parse::<u16>().map_err(|_| "Invalid tcp port")?);
+    if let Some(tcp) = matches.get_one::<String>("tcp-port") {
+        enr_builder.tcp4(tcp.parse::<u16>().map_err(|_| "Invalid tcp port")?);
     }
 
-    if let Some(udp) = matches.value_of("udp-port") {
-        enr_builder.udp(udp.parse::<u16>().map_err(|_| "Invalid udp port")?);
+    if let Some(udp) = matches.get_one::<String>("udp-port") {
+        enr_builder.udp4(udp.parse::<u16>().map_err(|_| "Invalid udp port")?);
     }
 
-    if let Some(eth2) = matches.value_of("eth2") {
+    if let Some(eth2) = matches.get_one::<String>("eth2") {
         let eth2_bytes = hex::decode(eth2).map_err(|_| "Invalid eth2 hex bytes")?;
         EnrForkId::from_ssz_bytes(&eth2_bytes).map_err(|_| "Invalid eth2 ssz bytes")?;
 

--- a/src/enr_ext.rs
+++ b/src/enr_ext.rs
@@ -1,6 +1,7 @@
 //! ENR extension trait to support libp2p integration.
 use enr::{CombinedKey, CombinedPublicKey};
 use libp2p_core::{identity::Keypair, identity::PublicKey, multiaddr::Protocol, Multiaddr, PeerId};
+use std::net::IpAddr;
 use tiny_keccak::{Hasher, Keccak};
 
 pub type Enr = enr::Enr<enr::CombinedKey>;
@@ -25,6 +26,9 @@ pub trait EnrExt {
 
     /// Returns any multiaddrs that contain the TCP protocol.
     fn multiaddr_tcp(&self) -> Vec<Multiaddr>;
+
+    /// Returns the ENODE address of the ENR.
+    fn enode_id(&self) -> String;
 }
 
 /// Extend ENR CombinedPublicKey for libp2p types.
@@ -49,14 +53,14 @@ impl EnrExt for Enr {
     /// The vector remains empty if these fields are not defined.
     fn multiaddr(&self) -> Vec<Multiaddr> {
         let mut multiaddrs: Vec<Multiaddr> = Vec::new();
-        if let Some(ip) = self.ip() {
-            if let Some(udp) = self.udp() {
+        if let Some(ip) = self.ip4() {
+            if let Some(udp) = self.udp4() {
                 let mut multiaddr: Multiaddr = ip.into();
                 multiaddr.push(Protocol::Udp(udp));
                 multiaddrs.push(multiaddr);
             }
 
-            if let Some(tcp) = self.tcp() {
+            if let Some(tcp) = self.tcp4() {
                 let mut multiaddr: Multiaddr = ip.into();
                 multiaddr.push(Protocol::Tcp(tcp));
                 multiaddrs.push(multiaddr);
@@ -85,15 +89,15 @@ impl EnrExt for Enr {
     fn multiaddr_p2p(&self) -> Vec<Multiaddr> {
         let peer_id = self.peer_id();
         let mut multiaddrs: Vec<Multiaddr> = Vec::new();
-        if let Some(ip) = self.ip() {
-            if let Some(udp) = self.udp() {
+        if let Some(ip) = self.ip4() {
+            if let Some(udp) = self.udp4() {
                 let mut multiaddr: Multiaddr = ip.into();
                 multiaddr.push(Protocol::Udp(udp));
                 multiaddr.push(Protocol::P2p(peer_id.into()));
                 multiaddrs.push(multiaddr);
             }
 
-            if let Some(tcp) = self.tcp() {
+            if let Some(tcp) = self.tcp4() {
                 let mut multiaddr: Multiaddr = ip.into();
                 multiaddr.push(Protocol::Tcp(tcp));
                 multiaddr.push(Protocol::P2p(peer_id.into()));
@@ -125,8 +129,8 @@ impl EnrExt for Enr {
     fn multiaddr_p2p_tcp(&self) -> Vec<Multiaddr> {
         let peer_id = self.peer_id();
         let mut multiaddrs: Vec<Multiaddr> = Vec::new();
-        if let Some(ip) = self.ip() {
-            if let Some(tcp) = self.tcp() {
+        if let Some(ip) = self.ip4() {
+            if let Some(tcp) = self.tcp4() {
                 let mut multiaddr: Multiaddr = ip.into();
                 multiaddr.push(Protocol::Tcp(tcp));
                 multiaddr.push(Protocol::P2p(peer_id.into()));
@@ -151,8 +155,8 @@ impl EnrExt for Enr {
     fn multiaddr_p2p_udp(&self) -> Vec<Multiaddr> {
         let peer_id = self.peer_id();
         let mut multiaddrs: Vec<Multiaddr> = Vec::new();
-        if let Some(ip) = self.ip() {
-            if let Some(udp) = self.udp() {
+        if let Some(ip) = self.ip4() {
+            if let Some(udp) = self.udp4() {
                 let mut multiaddr: Multiaddr = ip.into();
                 multiaddr.push(Protocol::Udp(udp));
                 multiaddr.push(Protocol::P2p(peer_id.into()));
@@ -174,8 +178,8 @@ impl EnrExt for Enr {
     /// The vector remains empty if these fields are not defined.
     fn multiaddr_tcp(&self) -> Vec<Multiaddr> {
         let mut multiaddrs: Vec<Multiaddr> = Vec::new();
-        if let Some(ip) = self.ip() {
-            if let Some(tcp) = self.tcp() {
+        if let Some(ip) = self.ip4() {
+            if let Some(tcp) = self.tcp4() {
                 let mut multiaddr: Multiaddr = ip.into();
                 multiaddr.push(Protocol::Tcp(tcp));
                 multiaddrs.push(multiaddr);
@@ -189,6 +193,38 @@ impl EnrExt for Enr {
             }
         }
         multiaddrs
+    }
+
+    /// Returns the ENODE ID of the ENR as a string to be printed
+    fn enode_id(&self) -> String {
+        let node_id = self.node_id();
+        let enode = format!("enode://{}", hex::encode(node_id.raw()));
+        // Preference ipv4 over ipv6
+        if let Some((ip, tcp_port, udp_port)) = {
+            if let Some(ip) = self.ip4() {
+                let tcp_port = self.tcp4();
+                let udp_port = self.udp4();
+                Some((IpAddr::from(ip), tcp_port, udp_port))
+            } else if let Some(ip) = self.ip6() {
+                let tcp_port = self.tcp4();
+                let udp_port = self.udp4();
+                Some((IpAddr::from(ip), tcp_port, udp_port))
+            } else {
+                None
+            }
+        } {
+            let tcp_port = tcp_port
+                .map(|port| port.to_string())
+                .unwrap_or_else(|| "".to_string());
+            let mut updated_enode = format!("{}:{}:{}", enode, ip, tcp_port);
+            if let Some(udp_port) = udp_port {
+                updated_enode = format!("{}?discport={}", updated_enode, udp_port);
+            }
+            updated_enode
+        } else {
+            // There was no IP address, so leave blank and just print the hex address
+            enode
+        }
     }
 }
 

--- a/src/enr_ext.rs
+++ b/src/enr_ext.rs
@@ -216,9 +216,11 @@ impl EnrExt for Enr {
             let tcp_port = tcp_port
                 .map(|port| port.to_string())
                 .unwrap_or_else(|| "".to_string());
-            let mut updated_enode = format!("{}:{}:{}", enode, ip, tcp_port);
+            let mut updated_enode = format!("{}@{}:{}", enode, ip, tcp_port);
             if let Some(udp_port) = udp_port {
-                updated_enode = format!("{}?discport={}", updated_enode, udp_port);
+                if udp_port.to_string() != tcp_port {
+                    updated_enode = format!("{}?discport={}", updated_enode, udp_port);
+                }
             }
             updated_enode
         } else {

--- a/src/eth2_ext.rs
+++ b/src/eth2_ext.rs
@@ -7,7 +7,7 @@ pub const ETH2_ENR_KEY: &str = "eth2";
 /// The ENR field specifying the subnet bitfield.
 pub const BITFIELD_ENR_KEY: &str = "attnets";
 
-#[derive(Debug, Clone, PartialEq, Default, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Default, Encode, Decode, Eq)]
 pub struct EnrForkId {
     pub fork_digest: [u8; 4],
     pub next_fork_version: [u8; 4],


### PR DESCRIPTION
Upgrade to the latest ENR and also print an enode-id. 

This leaves the TCP field blank if one does not exist in the ENR. 

If an IP address does not exist, this does not print any ports. 