### PR TITLE
fix: temporarily require rand feature from libp2p-identity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ hex = "0.4.3"
 eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"
 tiny-keccak = "2.0.2"
-libp2p-identity = { version = "0.2.3", features = ['ecdsa', 'ed25519', 'peerid', 'secp256k1'] }
+# TODO: remove 'rand' feature when <https://github.com/libp2p/rust-libp2p/pull/5212> is merged
+libp2p-identity = { version = "0.2.8", features = ['ecdsa', 'ed25519', 'peerid', 'secp256k1', 'rand'] }


### PR DESCRIPTION
`enr-cli` was not building with the following error:
```
   Compiling libp2p-identity v0.2.8
error[E0433]: failed to resolve: use of undeclared crate or module `rand`
  --> /Users/dan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libp2p-identity-0.2.8/src/ecdsa.rs:98:43
   |
98 |         SecretKey(SigningKey::random(&mut rand::thread_rng()))
   |                                           ^^^^ use of undeclared crate or module `rand`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `libp2p-identity` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: failed to compile `enr-cli v0.5.1`, intermediate artifacts can be found at `/var/folders/65/m26_cf0d1lbdnp4dvzztr0th0000gn/T/cargo-installxhFN7G`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```

So this will need the `rand` feature enabled until https://github.com/libp2p/rust-libp2p/pull/5212 is merged